### PR TITLE
Sync with complate stream

### DIFF
--- a/src/main/java/com/github/complate/api/ComplateEngine.java
+++ b/src/main/java/com/github/complate/api/ComplateEngine.java
@@ -14,6 +14,23 @@ public interface ComplateEngine {
 
     /**
      * Invokes the <strong>render</strong> function of the given
+     * {@link ComplateScript} with the given stream and tag without any
+     * parameters.
+     *
+     * @param script     the script to be used as source
+     * @param stream     the stream to be passed into the render function of the
+     *                   script
+     * @param tag        the tag that is passed to the render function of the
+     *                   script
+     * @throws ComplateException if any error occurs
+     */
+    default void invoke(ComplateScript script, ComplateStream stream,
+                String tag) throws ComplateException {
+        invoke(script, stream, tag, null);
+    }
+
+    /**
+     * Invokes the <strong>render</strong> function of the given
      * {@link ComplateScript} with the given stream, tag and parameters.
      *
      * @param script     the script to be used as source
@@ -21,12 +38,12 @@ public interface ComplateEngine {
      *                   script
      * @param tag        the tag that is passed to the render function of the
      *                   script
-     * @param parameters the optional parameters that are passed to the render
-     *                   function of the script
+     * @param parameters the parameters that are passed to the render
+     *                   function of the script. May be <code>null</code>.
      * @throws ComplateException if any error occurs
      */
     void invoke(ComplateScript script, ComplateStream stream, String tag,
-                Object... parameters) throws ComplateException;
+                Map<String, ?> parameters) throws ComplateException;
 
     /**
      * Creates a new complate engine without any bindings.

--- a/src/main/java/com/github/complate/api/ComplateScript.java
+++ b/src/main/java/com/github/complate/api/ComplateScript.java
@@ -6,11 +6,11 @@ import java.io.InputStream;
 /**
  * IO Abstraction for a JavaScript script that is used by complate.
  * <p>The script is required to declare a function named <strong>render</strong>
- * that takes the arguments <strong>stream</strong>, <strong>tag</strong> and
- * <strong>params</strong>. The following code snippet shows an simple example:
+ * that takes the arguments <strong>view</strong>, <strong>params</strong> and
+ * <strong>stream</strong>. The following code snippet shows an simple example:
  * <pre>{@code
- * function render(stream, tag, params) {
- *   stream.writeln(tag);
+ * function render(view, params, stream) {
+ *   stream.writeln(view);
  *   stream.writeln(params);
  *   stream.flush();
  * }

--- a/src/main/java/com/github/complate/api/NashornComplateEngine.java
+++ b/src/main/java/com/github/complate/api/NashornComplateEngine.java
@@ -16,6 +16,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.SequenceInputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,7 +44,8 @@ final class NashornComplateEngine implements ComplateEngine {
     public void invoke(final ComplateScript bundle,
                        final ComplateStream stream,
                        final String tag,
-                       final Object... parameters) throws ComplateException {
+                       final Map<String, ?> parameters)
+            throws ComplateException {
         final String functionName = "render";
 
         try (Reader reader = readerForScript(bundle)) {
@@ -77,10 +79,10 @@ final class NashornComplateEngine implements ComplateEngine {
     }
 
     private static Object[] toVarArgs(ComplateStream stream, String tag,
-                                      Object... parameters) {
+                                      Map<String, ?> parameters) {
         final List<Object> args = new ArrayList<>();
         args.add(tag);
-        args.add(parameters.length == 0 ? parameters : parameters[0]);
+        args.add(parameters == null ? Collections.emptyMap() : parameters);
         args.add(stream);
         return args.toArray();
     }

--- a/src/main/java/com/github/complate/api/NashornComplateEngine.java
+++ b/src/main/java/com/github/complate/api/NashornComplateEngine.java
@@ -16,7 +16,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.SequenceInputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,9 +79,9 @@ final class NashornComplateEngine implements ComplateEngine {
     private static Object[] toVarArgs(ComplateStream stream, String tag,
                                       Object... parameters) {
         final List<Object> args = new ArrayList<>();
-        args.add(stream);
         args.add(tag);
-        args.addAll(Arrays.asList(parameters));
+        args.add(parameters.length == 0 ? parameters : parameters[0]);
+        args.add(stream);
         return args.toArray();
     }
 

--- a/src/test/java/com/github/complate/ComplateSampleTest.java
+++ b/src/test/java/com/github/complate/ComplateSampleTest.java
@@ -90,7 +90,7 @@ public class ComplateSampleTest {
             result);
     }
 
-    private String render(String tag, Object... parameters) {
+    private String render(String tag, Map<String, ?> parameters) {
         final ComplateEngine engine = ComplateEngine.create();
         final ComplateScript script = new ClasspathComplateScript("/sample.js");
         final StringComplateStream stream = new StringComplateStream();

--- a/src/test/java/com/github/complate/ComplateSampleTest.java
+++ b/src/test/java/com/github/complate/ComplateSampleTest.java
@@ -1,0 +1,102 @@
+package com.github.complate;
+
+import com.github.complate.api.ComplateEngine;
+import com.github.complate.api.ComplateScript;
+import com.github.complate.impl.io.ClasspathComplateScript;
+import com.github.complate.impl.io.StringComplateStream;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Uses the transpiled output of https://github.com/complate/complate-sample as
+ * "integration tests".
+ */
+public class ComplateSampleTest {
+
+    @Test
+    public void siteIndex_without_layout_should_be_rendered_correct() {
+        final Map<String, Object> parameters = new HashMap<>();
+        parameters.put("title", "Foo");
+        parameters.put("_layout", false);
+
+        String result = render("SiteIndex", parameters);
+
+        assertEquals(
+            "<!DOCTYPE html>\n" +
+            "<p>lorem ipsum dolor sit amet</p>",
+            result);
+    }
+
+    @Test
+    public void siteIndex_with_layout_should_be_rendered_correct() {
+        final Map<String, Object> parameters = new HashMap<>();
+        parameters.put("title", "Bar");
+        parameters.put("_layout", true);
+
+        String result = render("SiteIndex", parameters);
+
+        assertEquals(
+            "<!DOCTYPE html>\n" +
+            "<html>" +
+                "<head>" +
+                    "<meta charset=\"utf-8\">" +
+                    "<title>Bar</title>" +
+                "</head>" +
+                "<body>" +
+                    "<h1>Bar</h1>" +
+                    "<p>lorem ipsum dolor sit amet</p>" +
+                "</body>" +
+            "</html>",
+            result);
+    }
+
+    @Test
+    public void bootstrapSample_should_be_rendered_correct() {
+        final Map<String, Object> parameters = new HashMap<>();
+        parameters.put("title", "Bootstrap");
+
+        String result = render("BootstrapSample", parameters);
+
+        assertEquals(
+            "<!DOCTYPE html>\n" +
+            "<html>" +
+                "<head>" +
+                    "<meta charset=\"utf-8\">" +
+                    "<title>Bootstrap</title>" +
+                    "<link rel=\"stylesheet\" href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css\" integrity=\"sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u\" crossorigin=\"anonymous\">" +
+                "</head>" +
+                "<body class=\"container-fluid\">" +
+                    "<h1>Bootstrap</h1>" +
+                    "<div class=\"panel panel-default\">" +
+                        "<div class=\"panel-heading\">" +
+                            "<h3 class=\"panel-title\">Welcome</h3>" +
+                        "</div>" +
+                        "<div class=\"panel-body\">" +
+                            "<p>lorem ipsum</p>" +
+                            "<ul class=\"list-group\">" +
+                                "<li class=\"list-group-item\">foo</li>" +
+                                "<li class=\"list-group-item\"><em>bar</em></li>" +
+                                "<li class=\"list-group-item\">baz</li>" +
+                            "</ul>" +
+                            "<p>dolor sit amet</p>" +
+                        "</div>" +
+                    "</div>" +
+                "</body>" +
+            "</html>",
+            result);
+    }
+
+    private String render(String tag, Object... parameters) {
+        final ComplateEngine engine = ComplateEngine.create();
+        final ComplateScript script = new ClasspathComplateScript("/sample.js");
+        final StringComplateStream stream = new StringComplateStream();
+
+        engine.invoke(script, stream, tag, parameters);
+
+        return stream.getContent();
+    }
+}

--- a/src/test/resources/bundle-bindings-test.js
+++ b/src/test/resources/bundle-bindings-test.js
@@ -1,4 +1,4 @@
-function render(stream) {
+function render(view, params, stream, options, callback) {
   stream.writeln(firstBinding.run("Hello"));
   stream.writeln(secondBinding.run("Bye"));
   stream.flush();

--- a/src/test/resources/bundle-global-obj.js
+++ b/src/test/resources/bundle-global-obj.js
@@ -1,4 +1,4 @@
-function render(stream, tag, params) {
+function render(view, params, stream, options, callback) {
   stream.writeln(global);
   stream.flush();
 }

--- a/src/test/resources/bundle.js
+++ b/src/test/resources/bundle.js
@@ -1,5 +1,5 @@
-function render(stream, tag, params) {
-  stream.writeln(tag);
+function render(view, params, stream, options, callback) {
+  stream.writeln(view);
   stream.writeln(params.title);
   stream.flush();
 }

--- a/src/test/resources/sample.js
+++ b/src/test/resources/sample.js
@@ -435,7 +435,7 @@ var views = Object.freeze({
 var renderer = new Renderer$1("<!DOCTYPE html>");
 Object.keys(views).map(function (key) {
 	return views[key];
-}).map(function (view) {
+}).forEach(function (view) {
 	return renderer.registerView(view);
 });
 var index = renderer.renderView.bind(renderer);

--- a/src/test/resources/sample.js
+++ b/src/test/resources/sample.js
@@ -1,0 +1,445 @@
+var render = (function () {
+'use strict';
+
+if(typeof global === "undefined" && typeof window !== "undefined") {
+	window.global = window;
+}
+
+var BLANKS = [undefined, null, false];
+function awaitAll(total, callback) {
+	var i = 0;
+	return function (_) {
+		i++;
+		if (i === total) {
+			callback();
+		}
+	};
+}
+function flatCompact(items) {
+	return items.reduce(function (memo, item) {
+		return BLANKS.indexOf(item) !== -1 ? memo : memo.concat(item.pop ? flatCompact(item) : item);
+	}, []);
+}
+function noop() {}
+
+var classCallCheck = function (instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+};
+
+var createClass = function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+
+  return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) defineProperties(Constructor, staticProps);
+    return Constructor;
+  };
+}();
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+var toArray = function (arr) {
+  return Array.isArray(arr) ? arr : Array.from(arr);
+};
+
+var toConsumableArray = function (arr) {
+  if (Array.isArray(arr)) {
+    for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i];
+
+    return arr2;
+  } else {
+    return Array.from(arr);
+  }
+};
+
+var VOID_ELEMENTS = {};
+["area", "base", "br", "col", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr"].forEach(function (tag) {
+	VOID_ELEMENTS[tag] = true;
+});
+function generateHTML(tag, params) {
+	for (var _len = arguments.length, children = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+		children[_key - 2] = arguments[_key];
+	}
+	return function (stream, nonBlocking, callback) {
+		stream.write("<" + tag + generateAttributes(params, tag) + ">");
+		children = flatCompact(children);
+		var total = children.length;
+		if (total === 0) {
+			closeElement(stream, tag, callback);
+		} else {
+			var close = awaitAll(total, function (_) {
+				closeElement(stream, tag, callback);
+			});
+			processChildren(stream, children, nonBlocking, close);
+		}
+	};
+}
+function HTMLString(str) {
+	this.value = str;
+}
+function htmlEncode(str, attribute) {
+	var res = str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+	if (attribute) {
+		res = res.replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
+	}
+	return res;
+}
+function processChildren(stream, children, nonBlocking, callback) {
+	var _children = toArray(children),
+	    child = _children[0],
+	    remainder = _children.slice(1);
+	if (child.call) {
+		if (child.length !== 1) {
+			child(stream, nonBlocking, callback);
+		} else {
+			var fn = function fn(element) {
+				element(stream, nonBlocking, callback);
+				if (remainder.length) {
+					processChildren(stream, remainder, nonBlocking, callback);
+				}
+			};
+			if (nonBlocking) {
+				child(fn);
+			} else {
+				var invoked = false;
+				var _fn = fn;
+				fn = function fn() {
+					invoked = true;
+					return _fn.apply(null, arguments);
+				};
+				child(fn);
+				if (!nonBlocking && !invoked) {
+					throw new Error("invalid non-blocking operation detected");
+				}
+			}
+			return;
+		}
+	} else {
+		var content = child instanceof HTMLString ? child.value : htmlEncode(child.toString());
+		stream.write(content);
+		callback();
+	}
+	if (remainder.length) {
+		processChildren(stream, remainder, nonBlocking, callback);
+	}
+}
+function closeElement(stream, tag, callback) {
+	if (!VOID_ELEMENTS[tag]) {
+		stream.write("</" + tag + ">");
+	}
+	stream.flush();
+	callback();
+}
+function generateAttributes(params, tag) {
+	if (!params) {
+		return "";
+	}
+	var attribs = Object.keys(params).reduce(function (memo, name) {
+		var value = params[name];
+		switch (value) {
+			case null:
+			case undefined:
+				break;
+			case true:
+				memo.push(name);
+				break;
+			case false:
+				break;
+			default:
+				if (/ |"|'|>|'|\/|=/.test(name)) {
+					abort("invalid HTML attribute name: " + repr(name), tag);
+				}
+				if (typeof value === "number") {
+					value = value.toString();
+				} else if (!value.substr) {
+					abort("invalid value for HTML attribute `" + name + "`: " + (repr(value) + " (expected string)"), tag);
+				}
+				memo.push(name + "=\"" + htmlEncode(value, true) + "\"");
+		}
+		return memo;
+	}, []);
+	return attribs.length === 0 ? "" : " " + attribs.join(" ");
+}
+function abort(msg, tag) {
+	if (tag) {
+		msg += " - did you perhaps intend to use `" + tag + "` as a macro?";
+	}
+	throw new Error(msg);
+}
+function repr(value) {
+	return "`" + JSON.stringify(value) + "`";
+}
+
+function createElement(element, params) {
+	for (var _len = arguments.length, children = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+		children[_key - 2] = arguments[_key];
+	}
+	return element.call ? element.apply(undefined, [params === null ? {} : params].concat(toConsumableArray(flatCompact(children)))) : generateHTML.apply(undefined, [element, params].concat(children));
+}
+var Renderer$1 = function () {
+	function Renderer() {
+		var doctype = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "<!DOCTYPE html>";
+		classCallCheck(this, Renderer);
+		this._doctype = doctype;
+		this._macroRegistry = {};
+		this.registerView.bind(this);
+		this.renderView.bind(this);
+	}
+	createClass(Renderer, [{
+		key: "registerView",
+		value: function registerView(macro) {
+			var name = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : macro.name;
+			var replace = arguments[2];
+			if (!name) {
+				throw new Error("missing name for macro: `" + macro + "`");
+			}
+			var macros = this._macroRegistry;
+			if (macros[name] && !replace) {
+				throw new Error("invalid macro name: `" + name + "` already registered");
+			}
+			macros[name] = macro;
+			return name;
+		}
+	}, {
+		key: "renderView",
+		value: function renderView(view, params, stream) {
+			var _ref = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {},
+			    fragment = _ref.fragment;
+			var callback = arguments[4];
+			if (!fragment) {
+				stream.writeln(this._doctype);
+			}
+			if (fragment) {
+				if (!params) {
+					params = {};
+				}
+				params._layout = false;
+			}
+			var macro = view && view.substr ? this._macroRegistry[view] : view;
+			if (!macro) {
+				throw new Error("unknown view macro: `" + view + "` is not registered");
+			}
+			var element = createElement(macro, params);
+			if (callback) {
+				element(stream, true, callback);
+			} else {
+				element(stream, false, noop);
+			}
+		}
+	}]);
+	return Renderer;
+}();
+
+function DefaultLayout(_ref) {
+	var title = _ref.title,
+	    stylesheets = _ref.stylesheets,
+	    bodyClass = _ref.bodyClass;
+	for (var _len = arguments.length, children = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+		children[_key - 1] = arguments[_key];
+	}
+	return createElement(
+		"html",
+		null,
+		createElement(
+			"head",
+			null,
+			createElement("meta", { charset: "utf-8" }),
+			createElement(
+				"title",
+				null,
+				title
+			),
+			renderStyleSheets(stylesheets)
+		),
+		createElement(
+			"body",
+			{ "class": bodyClass },
+			children
+		)
+	);
+}
+function renderStyleSheets(items) {
+	if (!items || !items.length) {
+		return;
+	}
+	return items.map(function (stylesheet) {
+		if (stylesheet.hash) {
+			var uri = stylesheet.uri,
+			    hash = stylesheet.hash;
+		} else {
+			uri = stylesheet;
+		}
+		return createElement("link", { rel: "stylesheet", href: uri,
+			integrity: hash, crossorigin: "anonymous" });
+	});
+}
+
+function SiteIndex(_ref) {
+	var title = _ref.title,
+	    _layout = _ref._layout;
+	var content = createElement(
+		"p",
+		null,
+		"lorem ipsum dolor sit amet"
+	);
+	return _layout === false ? content : createElement(
+		DefaultLayout,
+		{ title: title },
+		createElement(
+			"h1",
+			null,
+			title
+		),
+		content
+	);
+}
+
+function Panel(_ref) {
+	var title = _ref.title;
+	for (var _len = arguments.length, content = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+		content[_key - 1] = arguments[_key];
+	}
+	return createElement(
+		"div",
+		{ "class": "panel panel-default" },
+		createElement(
+			"div",
+			{ "class": "panel-heading" },
+			createElement(
+				"h3",
+				{ "class": "panel-title" },
+				title
+			)
+		),
+		createElement(
+			"div",
+			{ "class": "panel-body" },
+			content
+		)
+	);
+}
+
+function ListGroup(_) {
+	for (var _len = arguments.length, items = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+		items[_key - 1] = arguments[_key];
+	}
+	return createElement(
+		"ul",
+		{ "class": "list-group" },
+		items.map(function (item) {
+			return createElement(
+				"li",
+				{ "class": "list-group-item" },
+				item
+			);
+		})
+	);
+}
+
+var STYLESHEETS = [{
+	uri: "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css",
+	hash: "sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+}];
+function BootstrapSample(_ref) {
+	var title = _ref.title;
+	return createElement(
+		DefaultLayout,
+		{ title: title
+			, stylesheets: STYLESHEETS, bodyClass: "container-fluid" },
+		createElement(
+			"h1",
+			null,
+			title
+		),
+		createElement(
+			Panel,
+			{ title: "Welcome" },
+			createElement(
+				"p",
+				null,
+				"lorem ipsum"
+			),
+			createElement(
+				ListGroup,
+				null,
+				"foo",
+				createElement(
+					"em",
+					null,
+					"bar"
+				),
+				"baz"
+			),
+			createElement(
+				"p",
+				null,
+				"dolor sit amet"
+			)
+		)
+	);
+}
+
+
+
+var views = Object.freeze({
+	SiteIndex: SiteIndex,
+	BootstrapSample: BootstrapSample
+});
+
+var renderer = new Renderer$1("<!DOCTYPE html>");
+Object.keys(views).map(function (key) {
+	return views[key];
+}).map(function (view) {
+	return renderer.registerView(view);
+});
+var index = renderer.renderView.bind(renderer);
+
+return index;
+
+}());


### PR DESCRIPTION
This PR adapts to some changes/understandings from complate-stream.

 1. The order of parameters for the `render` function is changed to be the same as `Renderer#renderView`.
 2. The examples from `complate-sample` are added as tests
 3. The `ComplateEngine` API was adapted to model view parameters as `Map<String, ?>` instead of `Object...`.