### PR TITLE
Allow this to run with OpenJDK 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.13.0</version>
+      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Attempting to run `./mvnw clean install` as suggested by the README is greeted with a lot of error messages from Mockito. Key messages:

    Underlying exception : java.lang.UnsupportedOperationException: Cannot define class using reflection 
    Caused by: java.lang.IllegalStateException: Could not find sun.misc.Unsafe

This pull request fixes that problem.
