### PR TITLE
Add NashornComplateAdapter using Nashorn from JAR file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### 📣 Notes
-- `NashornComplateRenderer` is removed. Migrate to the `GraalComplateRenderer` ([c5aba0e](https://github.com/complate/complate-java/commit/c5aba0e6f879f346f8ef9a5a6150ba1e493960ec)).
+- `NashornComplateRenderer` has been updated to use the open source
+  [`org.openjdk.nashorn`](https://github.com/szegedi/nashorn) branch of Nashorn
+  since Nashorn has been removed from newer JDK versions
 
 ### 🔨 Dependency Upgrades
 - Upgrade to Graal 21.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,11 @@
       <artifactId>js</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.nashorn</groupId>
+      <artifactId>nashorn-core</artifactId>
+      <version>15.4</version>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>

--- a/src/main/java/org/complate/nashorn/NashornComplateRenderer.java
+++ b/src/main/java/org/complate/nashorn/NashornComplateRenderer.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2019 complate.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.complate.nashorn;
+
+import org.openjdk.nashorn.api.scripting.NashornException;
+import org.openjdk.nashorn.api.scripting.NashornScriptEngine;
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import org.complate.core.ComplateException;
+import org.complate.core.ComplateRenderer;
+import org.complate.core.ComplateSource;
+import org.complate.core.ComplateStream;
+
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+import static javax.script.ScriptContext.ENGINE_SCOPE;
+import static org.openjdk.nashorn.api.scripting.NashornException.getScriptStackString;
+
+/**
+ * {@link NashornScriptEngine} based {@link ComplateRenderer}.
+ *
+ * @author mvitz
+ * @since 0.1.0
+ */
+public final class NashornComplateRenderer implements ComplateRenderer {
+
+    private static final String POLYFILLS =
+        "if(typeof global === \"undefined\") { var global = this; }\n" +
+            "if(typeof console === \"undefined\") { var console = { log: print, error: print }; }\n" +
+            "\n";
+
+    private final NashornScriptEngine engine;
+
+    public NashornComplateRenderer(ComplateSource source) {
+        this(source, emptyMap());
+    }
+
+    public NashornComplateRenderer(ComplateSource source, Map<String, ?> bindings) {
+        engine = createEngine(bindings);
+
+        try {
+            engine.eval(POLYFILLS);
+        } catch (ScriptException e) {
+            throw new ComplateException(e, "Could not evaluate nashorn polyfills");
+        }
+
+        engine.put("javax.script.filename", source.getDescription());
+        try (Reader reader = readerFor(source)) {
+            engine.eval(reader);
+        } catch (IOException e) {
+            throw new ComplateException("failed to read script from source '%s'", source.getDescription());
+        } catch (ScriptException e) {
+            throw extractJavaScriptError(e)
+                .map(jsError -> new ComplateException(e, "failed to evaluate script: %s", jsError))
+                .orElseGet(() -> new ComplateException(e, "failed to evaluate script from resource '%s'", source.getDescription()));
+        }
+    }
+
+    @Override
+    public void render(String view, Map<String, ?> parameters, ComplateStream stream) throws ComplateException {
+        try {
+            final Object[] args = toVarArgs(view, parameters, stream);
+            engine.invokeFunction("render", args);
+        } catch (NoSuchMethodException e) {
+            throw new ComplateException(e, "could not find 'render' method in script");
+        } catch (ScriptException e) {
+            throw extractJavaScriptError(e)
+                .map(jsError -> new ComplateException(e, "failed to render: %s", jsError))
+                .orElseGet(() -> new ComplateException(e, "failed to render"));
+        }
+    }
+
+    private static NashornScriptEngine createEngine(Map<String, ?> bindings) {
+        final NashornScriptEngine engine = createEngine();
+
+        final Bindings engineBindings = engine.getBindings(ENGINE_SCOPE);
+        bindings.forEach(engineBindings::put);
+
+        return engine;
+    }
+
+    private static NashornScriptEngine createEngine() {
+        final ScriptEngine engine =
+            new NashornScriptEngineFactory().getScriptEngine();
+        if (engine == null) {
+            throw new ComplateException("Cannot instantiate Nashorn Script Engine");
+        }
+        return (NashornScriptEngine) engine;
+    }
+
+    private static Reader readerFor(ComplateSource source) {
+        final InputStream is;
+        try {
+            is = source.getInputStream();
+        } catch (IOException e) {
+            throw new ComplateException(e, "failed to initialize input stream for source '%s'", source.getDescription());
+        }
+        final Reader isr = new InputStreamReader(is);
+        return new BufferedReader(isr);
+    }
+
+    private static Optional<String> extractJavaScriptError(Exception e) {
+        final Throwable cause = e.getCause();
+        if (cause instanceof NashornException) {
+            return Optional.of(cause.getMessage() + "\n" + getScriptStackString(cause));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static Object[] toVarArgs(String view, Map<String, ?> parameters, ComplateStream stream) {
+        final Object[] args = new Object[3];
+        args[0] = view;
+        args[1] = parameters == null ? emptyMap() : parameters;
+        args[2] = stream;
+        return args;
+    }
+}

--- a/src/test/java/org/complate/nashorn/NashornComplateRendererTests.java
+++ b/src/test/java/org/complate/nashorn/NashornComplateRendererTests.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2019 complate.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.complate.nashorn;
+
+import org.complate.core.ComplateException;
+import org.complate.core.ComplateRenderer;
+import org.complate.core.source.ComplateClasspathSource;
+import org.complate.core.stream.ComplateStringStream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NashornComplateRendererTests {
+
+    @Test
+    void new_sourceWithNonExistingBundle_throwsException() {
+        assertThatThrownBy(() -> new NashornComplateRenderer(new ComplateClasspathSource("/non_existing_bundle.js")))
+            .isInstanceOf(ComplateException.class)
+            .hasMessage("failed to initialize input stream for source 'class path source [/non_existing_bundle.js]'");
+    }
+
+    @Test
+    void new_sourceWithInvalidBundle_throwsException() {
+        assertThatThrownBy(() -> new NashornComplateRenderer(new ComplateClasspathSource("/invalid_bundle.js")))
+            .isInstanceOf(ComplateException.class)
+            .hasMessage(
+                "failed to evaluate script: class path source [/invalid_bundle.js]:18:0 Expected eof but found }\n" +
+                    "}\n" +
+                    "^\n");
+    }
+
+    @Test
+    void render_sourceWithoutRenderFunction_throwsException() {
+        // arrange
+        ComplateRenderer sut = new NashornComplateRenderer(
+            new ComplateClasspathSource("/bundle_without_render_function.js"));
+
+        // act + assert
+        assertThatThrownBy(() -> sut.render("view", emptyMap(), new ComplateStringStream()))
+            .isInstanceOf(ComplateException.class)
+            .hasMessage("could not find 'render' method in script");
+    }
+
+    @Test
+    void render_sourceWithRuntimeError_throwsException() {
+        // arrange
+        ComplateRenderer sut = new NashornComplateRenderer(
+            new ComplateClasspathSource("/bundle_with_runtime_error.js"));
+
+        // act + assert
+        assertThatThrownBy(() -> sut.render("view", emptyMap(), new ComplateStringStream()))
+            .isInstanceOf(ComplateException.class)
+            .hasMessage(
+                "failed to render: ReferenceError: \"foo\" is not defined\n" +
+                    "\tat render (class path source [/bundle_with_runtime_error.js]:17)");
+    }
+
+    @Nested
+    class WithSimpleBundle {
+
+        ComplateRenderer sut = new NashornComplateRenderer(
+            new ComplateClasspathSource("/simple_bundle.js"),
+            new HashMap<String, Object>() {{
+                put("constantBinding", "World");
+                put("functionBinding", new FunctionBinding());
+            }});
+
+        ComplateStringStream stream = new ComplateStringStream();
+
+        @Test
+        void render_listView_withAllParams_works() {
+            // arrange
+            Map<String, String> parameters = new HashMap<>();
+            parameters.put("a", "1");
+            parameters.put("b", "2");
+            parameters.put("c", "3");
+
+            // act
+            sut.render("list", parameters, stream);
+
+            // assert
+            assertThat(stream.getContent()).isEqualTo("Arguments: 1, 2, 3");
+        }
+
+        @Test
+        void render_globalView_shouldRenderAvailableGlobalObject() {
+            // act
+            sut.render("global", emptyMap(), stream);
+
+            // assert
+            assertThat(stream.getContent()).isEqualTo("[object global]");
+        }
+
+        @Test
+        void render_consoleView_shouldRenderAvailableConsoleStuff() {
+            // act
+            sut.render("console", emptyMap(), stream);
+
+            // assert
+            assertThat(stream.getContent()).isEqualTo(
+                "[object Object]\n" +
+                    "function print() { [native code] }\n" +
+                    "function print() { [native code] }");
+        }
+
+        @Test
+        void render_bindingsView_shouldProvideBindingsToView() {
+            // act
+            sut.render("bindings", emptyMap(), stream);
+
+            // assert
+            assertThat(stream.getContent()).isEqualTo("Hello, World!");
+        }
+    }
+
+    public static final class FunctionBinding {
+
+        public String greet(String name) {
+            return "Hello, " + name + "!";
+        }
+    }
+}


### PR DESCRIPTION
This adds the NashornComplateAdapter back into the project, but uses the
open source `org.openjdk.nashorn` dependency to include Nashorn into the
project, since Nashorn has been removed from newer versions of the JDK.
This should allow us to be able to still use the NashornComplateAdapter
even for newer Java versions.